### PR TITLE
Fix unescaped '\' in regexps in Python code

### DIFF
--- a/generate-html.py
+++ b/generate-html.py
@@ -91,8 +91,8 @@ def slugify(value):
     """
     value = unicode(value)
     value = unicodedata.normalize('NFKD', value).encode('ascii', 'ignore').decode('ascii')
-    value = re.sub('[^\w\s-]', '', value).strip().lower()
-    return re.sub('[-\s]+', '_', value)
+    value = re.sub(r'[^\w\s-]', '', value).strip().lower()
+    return re.sub(r'[-\s]+', '_', value)
 
 
 def load_overlay(overlay):

--- a/markjaml.py
+++ b/markjaml.py
@@ -20,8 +20,8 @@ def slugify(value):
     """
     value = unicode(value)
     value = unicodedata.normalize('NFKD', value).encode('ascii', 'ignore').decode('ascii')
-    value = re.sub('[^\w\s-]', '-', value).strip().lower()
-    return re.sub('[-\s]+', '-', value)
+    value = re.sub(r'[^\w\s-]', '-', value).strip().lower()
+    return re.sub(r'[-\s]+', '-', value)
 
 
 def load(file):
@@ -50,10 +50,10 @@ def load(file):
         _type = _data.group(0)[4:8].upper().strip()
 
         if _type == 'JSON':
-            _data = re.search('\{(.*)\}', _data.group(0), re.DOTALL).group(0)
+            _data = re.search(r'\{(.*)\}', _data.group(0), re.DOTALL).group(0)
             _data = json.loads(_data)
         elif _type == '---':
-            _data = re.search('\n(.*)\n', _data.group(0), re.DOTALL).group(0)
+            _data = re.search(r'\n(.*)\n', _data.group(0), re.DOTALL).group(0)
             _data = yaml.safe_load(_data)
         else:
             data = {}

--- a/urlmapper.py
+++ b/urlmapper.py
@@ -28,8 +28,8 @@ def url_slugify(value):
     """
     value = unicode(value)
     value = unicodedata.normalize('NFKD', value).encode('ascii', 'ignore').decode('ascii')
-    value = re.sub('[^\w\s-]', '', value).strip().lower()
-    return re.sub('[-\s]+', '_', value)
+    value = re.sub(r'[^\w\s-]', '', value).strip().lower()
+    return re.sub(r'[-\s]+', '_', value)
 
 
 def load_overlay_url(overlay, lang):


### PR DESCRIPTION
Fix unescaped `\` in regexps in Python code.