### PR TITLE
CI: upgrade GitHub actions

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Python 3.11
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: 3.11
 


### PR DESCRIPTION
Upgrade actions/checkout and actions/setup-python to match latest releases.
See https://github.com/actions/setup-python?tab=readme-ov-file#basic-usage