### PR TITLE
Sponsorship: September 2026 (merge me on the 5th September)

### DIFF
--- a/common/boards.html
+++ b/common/boards.html
@@ -5,7 +5,7 @@
 			</aside>
 			<div id="interfaces">
 				<div>
-					Support us: <a href="https://www.pcbway.com/?from=pinout.xyz03">Build your first project with <strong>PCBWay</strong></a>
+					Support me: <a href="https://www.pcbway.com/?from=pinout.xyz04">Build your first project with <strong>PCBWay</strong></a>
 				</div>
 				<ul>
 				{{interfaces}}

--- a/common/page.html
+++ b/common/page.html
@@ -79,7 +79,7 @@
 			</aside>
 			<div id="interfaces">
 				<div>
-					Support us: <a href="https://www.pcbway.com/?from=pinout.xyz03">Build your first project with <strong>PCBWay</strong></a>
+					Support me: <a href="https://www.pcbway.com/?from=pinout.xyz04">Build your first project with <strong>PCBWay</strong></a>
 				</div>
 				<ul>
 				{{interfaces}}

--- a/src/en/template/footer.html
+++ b/src/en/template/footer.html
@@ -1,3 +1,6 @@
 <p>Spotted an error, want to add your board's pinout? <a href="https://github.com/pinout-xyz/Pinout.xyz">Contribute to Pinout.xyz at GitHub</a></p>
 <p>Part of <a href="https://www.gadgetoid.com">gadgetoid.com</a>. Maintained by <a href="https://fosstodon.org/@gadgetoid">@Gadgetoid@fosstodon.org</a>.</p>
-<p>Help make Pinout.xyz better- please sponsor me at <a href="https://ko-fi.com/gadgetoid">Ko-Fi</a>, <a href="https://github.com/sponsors/Gadgetoid">GitHub</a> or <a href="https://www.patreon.com/gadgetoid">Patreon</a></p>
+<p>See also: <a title="Raspberry Pi Pico Pinout" href="https://pico.pinout.xyz/">Pico Pinout</a>
+| <a title="Raspberry Pi Pico W Pinout" href="https://picow.pinout.xyz/">Pico W Pinout</a>
+| <a title="Raspberry Pi Pico 2 Pinout" href="https://pico2.pinout.xyz/">Pico 2 Pinout</a>
+| <a title="Raspberry Pi Pico 2 W Pinout" href="https://pico2w.pinout.xyz/">Pico 2 W Pinout</a></p>

--- a/src/en/template/index.md
+++ b/src/en/template/index.md
@@ -6,7 +6,7 @@ This GPIO Pinout is an interactive reference to the Raspberry Pi GPIO pins, and 
 
 ## Other Pinouts
 
-We've created Pinouts for the Raspberry Pi Pico range of boards, too, you can find them here:
+We've created Pinouts for the Raspberry Pi Pico range of boards, you can find them here:
 
 * [Raspberry Pi Pico Pinout](https://pico.pinout.xyz)
 * [Raspberry Pi Pico W Pinout](https://picow.pinout.xyz)
@@ -18,7 +18,7 @@ Plus chip planners for the RP2350A and RP2350B chips:
 * [Raspberry Pi RP2350A QFN-60 Pinout](https://rp2350a.pinout.xyz)
 * [Raspberry Pi RP2350B QFN-80 Pinout](https://rp2350b.pinout.xyz)
 
-And some experimental pinouts, too:
+And some experimental pinouts:
 
 * [Minimal Raspberry Pi 40-pin Pinout](https://pi.pinout.xyz)
 * [Espressif ESP32 C5 DevKitC Pinout](https://esp32c5.pinout.xyz)
@@ -33,5 +33,5 @@ And some experimental pinouts, too:
 
 * GPIO - General Purpose Input/Output, aka "BCM" or "Broadcom". These are the big numbers, e.g. "GPIO 22". You'll use these with RPi.GPIO and GPIO Zero.
 * Physical - or "Board" correspond to the pin's physical location on the header. These are the small numbers next to the header, e.g. "Physical Pin 15".
-* WiringPi - for Gordon Henderson's Wiring Pi library. These are shown as a tooltip when you mouseover a pin.
+* WiringPi - for the Wiring Pi library. These are shown as a tooltip when you mouseover a pin.
 * Rev 1 Pi - alternate GPIO/BCM numbers for the original, 26-pin model "A" and "B" Pi. The 40-pin header is a superset of that 26-pin one: pins 1 to 26 carry the same signals, so a 26-pin board or wiring diagram still applies.


### PR DESCRIPTION
I decided it was a little trite to include the sponsorship links at the bottom when PCBWay have been generously funding Pinout.xyz for the last nine months. They have just renewed for another six.

Broadly they have been great to work with, very hands-off, with only occasional requests for specific promotions (the last of which I totally missed.)

Suffice to say the sponsorship has had the desired effect of motivating me into keeping this site up to date and polished, including finally landing some of the accessibility changes I had been planning. Not to mention the *huge* sweep through my backlog.

This is with the notable exception of adding new boards- I realistically don't have the time to acquire, test, photograph and document HATs beyond the ones I'm directly involved with.